### PR TITLE
Citygml fixes plus compression

### DIFF
--- a/citygml/build-citygml.sh
+++ b/citygml/build-citygml.sh
@@ -38,4 +38,8 @@ OUTFILE_PREFIX="${OCM_STATE}-${OCM_COUNTY}"
 java -server -jar citygml.jar ${OCM_BLDGSFILES} ${OCM_GMLFILES} ${OUTFILE_PREFIX}
 
 # push the citygml files back to S3
-aws s3 cp ${OCM_GMLFILES} s3://${OCM_GML_S3BUCKET}/${OCM_STATE}/ --recursive
+if [ $? -eq 0 ]; then
+    aws s3 cp ${OCM_GMLFILES} s3://${OCM_GML_S3BUCKET}/${OCM_STATE}/ --recursive
+else
+    exit 1
+fi

--- a/citygml/pom.xml
+++ b/citygml/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.opencitymodel</groupId>
     <artifactId>citygml</artifactId>
-    <version>0.1-SNAPSHOT</version>
+    <version>0.2-SNAPSHOT</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/citygml/src/main/java/org/opencitymodel/citygml/CitygmlBuilder.java
+++ b/citygml/src/main/java/org/opencitymodel/citygml/CitygmlBuilder.java
@@ -77,42 +77,37 @@ public final class CitygmlBuilder {
      *
      * @param path Filesystem path where the citygml should be written.
      */
-    public void writeFile(String path, String filename) {
+    public void writeFile(String path, String filename) throws Exception {
 
-        try {
-            CityModel cityModel = new CityModel();
+        CityModel cityModel = new CityModel();
 
-            // add our collected buildings to our city model
-            for( BuildingDef bldg : buildings ) {
-                Building building = createBuilding(bldg);
-                cityModel.addCityObjectMember(new CityObjectMember(building));
-            }
-
-            CityGMLContext ctx = CityGMLContext.getInstance();
-            CityGMLBuilder builder = ctx.createCityGMLBuilder(getClass().getClassLoader());
-            CityGMLOutputFactory out = builder.createCityGMLOutputFactory(CityGMLVersion.DEFAULT);
-
-            // we want a Zip compressed output
-            FileOutputStream fos = new FileOutputStream(path+"/"+filename+".zip");
-            BufferedOutputStream bos = new BufferedOutputStream(fos);
-            ZipOutputStream zos = new ZipOutputStream(bos);
-            zos.putNextEntry(new ZipEntry(filename+".gml"));
-            CityGMLWriter writer = out.createCityGMLWriter(zos, "UTF-8");
-
-            // add 'boundedBy' element along with coordinate system
-            BoundingShape bbox = cityModel.calcBoundedBy(BoundingBoxOptions.defaults());
-            bbox.getEnvelope().setSrsName(this.targetCrs);
-            cityModel.setBoundedBy(bbox);
-
-            writer.setPrefixes(CityGMLVersion.DEFAULT);
-            writer.setSchemaLocations(CityGMLVersion.DEFAULT);
-            writer.setIndentString("  ");
-            writer.write(cityModel);
-            writer.close();
-
-        } catch(Exception e) {
-            e.printStackTrace();
+        // add our collected buildings to our city model
+        for( BuildingDef bldg : buildings ) {
+            Building building = createBuilding(bldg);
+            cityModel.addCityObjectMember(new CityObjectMember(building));
         }
+
+        CityGMLContext ctx = CityGMLContext.getInstance();
+        CityGMLBuilder builder = ctx.createCityGMLBuilder(getClass().getClassLoader());
+        CityGMLOutputFactory out = builder.createCityGMLOutputFactory(CityGMLVersion.DEFAULT);
+
+        // we want a Zip compressed output
+        FileOutputStream fos = new FileOutputStream(path+"/"+filename+".zip");
+        BufferedOutputStream bos = new BufferedOutputStream(fos);
+        ZipOutputStream zos = new ZipOutputStream(bos);
+        zos.putNextEntry(new ZipEntry(filename+".gml"));
+        CityGMLWriter writer = out.createCityGMLWriter(zos, "UTF-8");
+
+        // add 'boundedBy' element along with coordinate system
+        BoundingShape bbox = cityModel.calcBoundedBy(BoundingBoxOptions.defaults());
+        bbox.getEnvelope().setSrsName(this.targetCrs);
+        cityModel.setBoundedBy(bbox);
+
+        writer.setPrefixes(CityGMLVersion.DEFAULT);
+        writer.setSchemaLocations(CityGMLVersion.DEFAULT);
+        writer.setIndentString("  ");
+        writer.write(cityModel);
+        writer.close();
     }
 
 

--- a/citygml/src/main/java/org/opencitymodel/citygml/CitygmlBuilder.java
+++ b/citygml/src/main/java/org/opencitymodel/citygml/CitygmlBuilder.java
@@ -3,6 +3,7 @@ package org.opencitymodel.citygml;
 import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
+import java.util.Base64;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 import java.util.ArrayList;
@@ -117,7 +118,7 @@ public final class CitygmlBuilder {
 
     private Building createBuilding(BuildingDef bldg) {
         Building building = new Building();
-        building.setId(bldg.getId());
+        building.setId(Base64.getEncoder().withoutPadding().encodeToString(bldg.getId().getBytes()));
 
         // convert the coordinates of the footprint into our desired CRS
         GeoJSON fp = bldg.getFp();

--- a/citygml/src/main/java/org/opencitymodel/citygml/Main.java
+++ b/citygml/src/main/java/org/opencitymodel/citygml/Main.java
@@ -89,7 +89,7 @@ public class Main {
 
     public void writeCitygml() {
         String outfile = this.name + "-" + String.format("%03d", this.index);
-        System.out.println(String.format("Writing %d buildings to file %s", this.builder.getNumBuildings(), this.path + "/" + outfile));
+        System.out.println(String.format("Writing %d buildings to file %s", this.builder.getNumBuildings(), outfile));
         this.builder.writeFile(this.path, outfile);
         // upload it to s3, delete it
         this.builder = new CitygmlBuilder(this.builder.getLod());

--- a/citygml/src/main/java/org/opencitymodel/citygml/Main.java
+++ b/citygml/src/main/java/org/opencitymodel/citygml/Main.java
@@ -88,9 +88,10 @@ public class Main {
     }
 
     public void writeCitygml() {
-        String outfile = this.path + "/" + this.name + "-" + String.format("%03d", this.index) + ".gml";
-        System.out.println(String.format("Writing %d buildings to file %s", this.builder.getNumBuildings(), outfile));
-        this.builder.writeFile(outfile);
+        String outfile = this.name + "-" + String.format("%03d", this.index);
+        System.out.println(String.format("Writing %d buildings to file %s", this.builder.getNumBuildings(), this.path + "/" + outfile));
+        this.builder.writeFile(this.path, outfile);
+        // upload it to s3, delete it
         this.builder = new CitygmlBuilder(this.builder.getLod());
         this.index++;
     }

--- a/citygml/src/main/java/org/opencitymodel/citygml/Main.java
+++ b/citygml/src/main/java/org/opencitymodel/citygml/Main.java
@@ -28,11 +28,11 @@ public class Main {
             System.out.println("Directory of files");
             try (Stream<Path> paths = Files.walk(Paths.get(indir))) {
                 paths.forEach(p -> {
-                    if(p.toFile().isFile() && p.toAbsolutePath().toString().endsWith(".json")) {
+                    if (p.toFile().isFile() && p.toAbsolutePath().toString().endsWith(".json")) {
                         main.processFile(p.toString());
                     }
                 });
-            } catch(IOException ioe) {
+            } catch (IOException ioe) {
                 ioe.printStackTrace();
             }
         } else if (file.isFile()) {
@@ -66,6 +66,7 @@ public class Main {
 
     public void processFile(String path) {
         System.out.println("processing: "+path);
+
         try {
             FileReader fileReader = new FileReader(new File(path));
             BufferedReader bufferedReader = new BufferedReader(fileReader);
@@ -82,17 +83,23 @@ public class Main {
             }
 
             fileReader.close();
-        } catch (IOException e) {
-            e.printStackTrace();
+        } catch(Exception ex) {
+            ex.printStackTrace();
+            System.exit(1);
         }
     }
 
     public void writeCitygml() {
-        String outfile = this.name + "-" + String.format("%03d", this.index);
-        System.out.println(String.format("Writing %d buildings to file %s", this.builder.getNumBuildings(), outfile));
-        this.builder.writeFile(this.path, outfile);
-        // upload it to s3, delete it
-        this.builder = new CitygmlBuilder(this.builder.getLod());
-        this.index++;
+        try {
+            String outfile = this.name + "-" + String.format("%03d", this.index);
+            System.out.println(String.format("Writing %d buildings to file %s", this.builder.getNumBuildings(), outfile));
+            this.builder.writeFile(this.path, outfile);
+            // upload it to s3, delete it
+            this.builder = new CitygmlBuilder(this.builder.getLod());
+            this.index++;
+        } catch(Exception ex) {
+            ex.printStackTrace();
+            System.exit(1);
+        }
     }
 }

--- a/citygml/submit-citygml-job.sh
+++ b/citygml/submit-citygml-job.sh
@@ -3,7 +3,7 @@
 # Simple script which wraps the AWS cmd line tool and is meant for submitting
 # a job to generate citygml for a given state & county
 NAME="citygml"
-REVISION="3"
+REVISION="4"
 QUEUE="SmallBatchJobs"
 
 STATE=$1


### PR DESCRIPTION
resolves #29 
resolves #28 
resolves #27 

Fixes two issues with the citygml creation which did not conform to the specification.  First was not have a unit-of-measure on the `measuredHeight` attribute of the building, and the second was having invalid `gml:id` values which started with numbers.  Both of these have been resolved.

We've also gone ahead and updated the citygml writing so that we write directly to ZIP compressed files to keep file sizes smaller.

Last little fix was to tweak our error handling so that if the java citygml creation process generates any exceptions we bail out and fail with an error code instead of silently capturing those exceptions.