### PR TITLE
Improve gridding

### DIFF
--- a/footprints/grid-and-attrs/app.js
+++ b/footprints/grid-and-attrs/app.js
@@ -69,6 +69,7 @@ function writeFootprint(state, mgrsGrid, outdir, building) {
     const match = MGRS_REGEX.exec(mgrsGrid);
     const gzd = match[1];
     const gsid = match[2];
+    const zone10k = match[3].substring(0, 1) + match[3].substring(2, 3);
 
     // make sure our folder path exists, otherwise we can't open up the actual files
     mkdirp(outdir+"/"+state, function(err) {
@@ -76,7 +77,7 @@ function writeFootprint(state, mgrsGrid, outdir, building) {
             console.log("error creating directory", outdir+"/"+outpath, err);
         } else {
             // TODO: this could probably be more efficient
-            fs.appendFile(`${outdir}/${state}/${gzd}${gsid}.txt`, JSON.stringify(building)+"\n", function (err) {
+            fs.appendFile(`${outdir}/${state}/${gzd}${gsid}${zone10k}.txt`, JSON.stringify(building)+"\n", function (err) {
                 if (err) console.log("error writing to", mgrsGrid, err);
             });
         }

--- a/footprints/grid-and-attrs/submit-all-states.sh
+++ b/footprints/grid-and-attrs/submit-all-states.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+declare -a states=("Alabama" "Alaska" "Arizona" "Arkansas" "California" "Colorado" "Connecticut" "Delaware" "DistrictofColumbia" "Florida" "Georgia" "Hawaii" "Idaho" "Illinois" "Indiana" "Iowa" "Kansas" "Kentucky" "Louisiana" "Maine" "Maryland" "Massachusetts" "Michigan" "Minnesota" "Mississippi" "Missouri" "Montana" "Nebraska" "Nevada" "NewHampshire" "NewJersey" "NewMexico" "NewYork" "NorthCarolina" "NorthDakota" "Ohio" "Oklahoma" "Oregon" "Pennsylvania" "RhodeIsland" "SouthCarolina" "SouthDakota" "Tennessee" "Texas" "Utah" "Vermont" "Virginia" "Washington" "WestVirginia" "Wisconsin" "Wyoming")
+
+
+# move through county numbers (2 at a time) until we hit max
+for state in "${states[@]}"
+do
+   ./submit-grid-job.sh $1 $state
+done


### PR DESCRIPTION
resolves #42 
resolves #50 

* apply a fix for how MultiPolygon county shapes are tested on buildings where we couldn't determine the county from our mapping file.
* reduce the number of output files (dramatically) by grouping buildings by 10km mgrs grids instead of 1km.  we still attribute the 1km mgrs grid in the building attributes.