### PR TITLE
repair bad geometries and handle multi-polygon geometries

### DIFF
--- a/footprints/README.md
+++ b/footprints/README.md
@@ -1,7 +1,7 @@
 # Footprints Processing
 
 1. **Data Preparation** - the files in the `data-prep` folder contain scripts which take raw data from various datasets and transforms them into a known and standardized format for further processing.  for the most part these scripts do things such as extract compressed files and then transform ESRI shapefiles into our GeoJSON based footprints format.
-2. **Grid and Attributes** - in this step we take files which have been properly prepared and we do a pass over each footprint in order to A) add a set of common attributes to the data such as `center`, `mgrs`, and `ubid`, and B) to group the footprints into smaller files based on the 1km MGRS grid the footprint falls within.
+2. **Grid and Attributes** - in this step we take files which have been properly prepared and we do a pass over each footprint in order to A) add a set of common attributes to the data such as `center`, `mgrs`, and `ubid`, and B) to group the footprints into smaller files based on the MGRS grid the footprint falls within.
 
 
 # Prepared Data Format
@@ -9,5 +9,5 @@
 All footprints data that is ready to be processed should be placed in files that follow the following rules:
  - there should be a single file per US state which is named `<state>.txt`.  for example, California.txt
  - each line in the file should be a single JSON object.  no extra line breaks or other formatting should be present.
- - the JSON object on each line should represent a single building footprint structured as a GeoJSON `geometry`.  NOTE: this is not a full GeoJSON document and only a geometry.
+ - the JSON object on each line should represent a single building footprint structured as a GeoJSON `geometry`.  NOTE: this is not a full GeoJSON document, just a single Feature.
  - the coordinates in the geometry of the footprint should be provided in WGS84 coordinate system.

--- a/footprints/grid-and-attrs/lib/repair.js
+++ b/footprints/grid-and-attrs/lib/repair.js
@@ -1,0 +1,29 @@
+module.exports = {
+    // validate polygon and attempt to repair common issues
+    //
+    // if the geometry is deemed to be invalid and non-repairable for any reason then we should throw
+    // an error back to the caller detailing what the problem was with the geometry
+    //
+    // SEE: http://desktop.arcgis.com/en/arcmap/10.3/tools/data-management-toolbox/repair-geometry.htm
+    repairGeometry: geometry => {
+
+        //  Duplicate Vertices
+        if(_.some(geometry.coordinates, ring => {
+            return _.some(eachCons(ring, 2), coordsPair => {
+                return coordsPair[0][0] === coordsPair[1][0] && coordsPair[0][1] === coordsPair[1][1];
+            });
+        })) {
+            // console.log("duplicate coordinates found in polygon ring", geometry.coordinates);
+            const coordinates = geometry.coordinates.map(ring => {
+                // only keep unique points in the polygon
+                const uniqueRing = _.uniq(ring, true, c => c[0]+c[1]);
+                // the above will strip out the final point in the polygon which is the same as the first point, so add it back
+                return [ ...uniqueRing, uniqueRing[0]];
+            });
+
+            geometry = { ...geometry, coordinates };
+        }
+
+        return geometry;
+    }
+}

--- a/footprints/grid-and-attrs/package-lock.json
+++ b/footprints/grid-and-attrs/package-lock.json
@@ -76,6 +76,11 @@
         "xregexp": "4.0.0"
       }
     },
+    "each-cons": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/each-cons/-/each-cons-1.0.0.tgz",
+      "integrity": "sha1-6/QrbMbhGZPVXDhIy5q1fZBs9PE="
+    },
     "execa": {
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/execa/-/execa-0.10.0.tgz",

--- a/footprints/grid-and-attrs/package.json
+++ b/footprints/grid-and-attrs/package.json
@@ -12,6 +12,7 @@
     "@turf/area": "^6.0.1",
     "@turf/helpers": "^6.1.4",
     "byline": "^5.0.0",
+    "each-cons": "^1.0.0",
     "geolib": "^2.0.24",
     "mgrs": "^1.0.0",
     "mkdirp": "^0.5.1",


### PR DESCRIPTION
resolves #55
resolves #25 

start a simple function for `geometryRepair` which validates footprints and attempts to repair small issues.  also add in simple logic to avoid MULTI_POLYGON buildings and either skip them or change them to POLYGON where possible.